### PR TITLE
Fix a TypeError that occur when invoking render_plot()

### DIFF
--- a/evaluation/jupyter_notebooks/biwi_evaluation.ipynb
+++ b/evaluation/jupyter_notebooks/biwi_evaluation.ipynb
@@ -312,7 +312,7 @@
     "            poses.append(pose_pred)            \n",
     "        \n",
     "        if visualize and best_index >= 0:     \n",
-    "            render_plot(ori_img.copy(), pose_pred, bbox)\n",
+    "            render_plot(ori_img.copy(), pose_pred)\n",
     "\n",
     "    if len(poses) == 0:\n",
     "        total_failures += 1\n",


### PR DESCRIPTION
If |visualize| is True, biwi_evaluation.ipynb breaks at:

         59
         60         if visualize and best_index >= 0:
    ---> 61             render_plot(ori_img.copy(), pose_pred, bbox)
         62
         63     if len(poses) == 0:
    TypeError: render_plot() takes 2 positional arguments but 3 were given