### PR TITLE
Added scikit-image to dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -68,6 +68,7 @@ pyzmq==20.0.0
 requests==2.25.0
 requests-oauthlib==1.3.0
 rsa==4.6
+scikit-image==0.18.0
 scipy==1.5.4
 Send2Trash==1.5.0
 six==1.15.0


### PR DESCRIPTION
Required by utils/face_align.py (skimage)

Not sure if I missed something in the documentation, but I had to add this pip dependency for the "convert_json_list_to_lmdb.py" script to work.